### PR TITLE
Add support for vector and list on POSIX

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,7 +39,8 @@ jobs:
         dc:
           - ldc-latest
         target:
-          - { name: g++-9, compiler: g++, cxx-version: 9.4.0 }
+#          - { name: g++-9, compiler: g++, cxx-version: 9.4.0 }
+          - { name: clang-13, compiler: clang, cxx-version: 13.0.0 }
 
     # Using a specific version for reproductibility.
     # Feel free to update when a new release has matured.

--- a/dub.json
+++ b/dub.json
@@ -13,6 +13,21 @@
         },
         {
             "name": "unittest",
+            "lflags": [ "-lstdc++" ],
+            "preGenerateCommands": [
+                "clang++ -c extras/vector.cpp -o extras/vector.o",
+		"clang++ -c extras/list.cpp -o extras/list.o"
+            ],
+            "sourceFiles": [ "extras/*.o" ]
         },
+        {
+            "name": "unittest-gcc",
+            "lflags": [ "-lc++" ],
+            "preGenerateCommands": [
+                "g++ -c extras/vector.cpp -o extras/vector.o",
+		"g++ -c extras/list.cpp -o extras/list.o"
+            ],
+            "sourceFiles": [ "extras/*.o" ]
+        }
     ]
 }

--- a/extras/list.cpp
+++ b/extras/list.cpp
@@ -1,0 +1,3 @@
+#include <list>
+
+template class std::list<int>;

--- a/extras/vector.cpp
+++ b/extras/vector.cpp
@@ -1,0 +1,3 @@
+#include <vector>
+
+template class std::vector<int>;

--- a/source/stdcpp/list.d
+++ b/source/stdcpp/list.d
@@ -1,0 +1,293 @@
+/**
+ * D bindings for std::list
+ *
+ * Copyright: Copyright (c) 2023 D Language Foundation
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1.0.txt, Boost Software License 1.0).
+ *      (See accompanying file License)
+ * Authors: Emmanuel Nyarko, Mathias Lang
+ */
+module stdcpp.list;
+
+import stdcpp.allocator;
+
+version (CppRuntime_Gcc)
+{
+    version (GLIBCXX_USE_CXX98_ABI)
+    {
+        private enum listNamespace = "std";
+    }
+    else
+    {
+        import core.internal.traits : AliasSeq;
+        private enum listNamespace = AliasSeq!("std", "__cxx11");
+    }
+}
+else
+{
+    import stdcpp.xutility : StdNamespace;
+    alias listNamespace = StdNamespace;
+}
+
+enum def {value}; //for later use
+extern(C++, (listNamespace)):
+
+alias list(Type) = list!(Type, allocator!Type);
+
+extern(C++, class) struct list(Type, Allocator)
+{
+    static assert(!is(Type == bool), " list not required to have specialization for bool");
+
+    ///
+    alias value_type = Type;
+
+    ///
+    alias allocator_type = Allocator;
+
+    ///
+    alias size_type = size_t;
+
+    ///
+    alias pointer = Type*;
+
+    ///
+    alias const_pointer = const(Type)*;
+
+    ///
+    alias difference_type = ptrdiff_t;
+
+    ///
+    ref list opAssign();
+
+    ///
+    @disable this() @safe pure nothrow @nogc scope;
+
+    version (CppRuntime_Gcc)
+    {
+        version (GLIBCXX_USE_CXX98_ABI)
+        {
+            //allocator ctor
+            this(ref const allocator!Type);
+
+            //list(n,value) ctor until c++11
+            this(size_type __n, ref const value_type value, ref const allocator!Type);
+
+            /// Copy constructor
+            this(ref const list!Type __x);
+
+            extern(D) this(size_type n)
+            {
+                value_type type_instance = value_type.init;
+                allocator!Type alloc_instance = allocator!(Type).init;
+                this(n, type_instance, alloc_instance);
+            }
+
+            extern(D) void assign(size_type n, const value_type item)
+            {
+                this.assign(n, item);
+            }
+
+            extern(D) void push_back(const Type item)
+            {
+                this.push_back(item);
+            }
+
+            extern(D) void push_front(const Type item)
+            {
+                this.push_front(item);
+            }
+
+            extern(D) void remove(const value_type item)
+            {
+                this.remove(item);
+            }
+
+            void assign(size_type count, ref const value_type value);
+
+            ref list opAssign(ref const list!Type other);
+
+            //just const until c++11
+            allocator_type get_allocator() const;
+
+            ref value_type front();
+
+//          const(value_type) ref front() const;
+
+            ref value_type back();
+
+            pointer begin();
+
+            pointer end();
+
+            //just const until c++11
+            bool empty() const;
+
+            size_type size() const;
+
+            size_type max_size() const nothrow;
+
+            void clear();
+
+            //insert halted for now
+
+            void push_back(ref const Type val);
+
+            void pop_back();
+
+            void push_front(ref const value_type val);
+
+            void pop_front();
+
+            void swap(ref const list!Type other);
+
+            void merge( ref const list!Type other);
+
+            void merge(U)(ref const list!Type other, U comp);
+
+            void remove(const ref value_type val);
+
+            void reverse();
+
+            void sort();
+
+            size_type unique();
+
+            void sort(U)(U comp);
+
+            private struct node
+            {
+                node* prev;
+                node* next;
+            }
+            // pre-c++11 doesn't keep track of its size
+            private node A;
+        }
+        else // !GLIBCXX_USE_CXX98_ABI
+        {
+            this(def)
+            {
+                allocator!Type alloc_instance = allocator!(Type).init;
+                this(alloc_instance);
+            }
+
+             //allocator ctor
+            this(ref const allocator!Type);
+
+            // Copy constructor
+            this(ref const list!Type __x);
+
+             //list(n,value) ctor
+            this(size_type __n, ref const value_type value, ref const allocator!Type);
+
+            extern(D) this(size_type n, const value_type element)
+            {
+                allocator!Type alloc_instance = allocator!(Type).init;
+                this(n, element, alloc_instance);
+            }
+
+            this(ref const list!Type other, ref const allocator!Type);
+
+            //list(n) ctor
+            this(size_type __n, ref const allocator!Type);
+
+            extern(D) this(size_type n)
+            {
+                allocator!Type alloc_instance = allocator!(Type).init;
+                this(n, alloc_instance);
+            }
+
+            extern(D) void assign(size_type n, const value_type item)
+            {
+                this.assign(n, item);
+            }
+
+            extern(D) void push_back(const Type item)
+            {
+                this.push_back(item);
+            }
+
+            extern(D) void push_front(const Type item)
+            {
+                this.push_front(item);
+            }
+
+            extern(D) void resize(size_type n, const value_type item)
+            {
+                this.resize(n, item);
+            }
+
+            extern(D) void remove(const value_type item)
+            {
+                this.remove(item);
+            }
+
+            ref list opAssign(ref const list!Type other);
+
+            void assign(size_type count, ref const value_type value);
+
+            //const nothrow since C++11
+            allocator_type get_allocator() const nothrow;
+
+            ref value_type front();
+
+            ref value_type back();
+
+            pointer begin() nothrow;
+
+            pointer end() nothrow;
+
+            //const nothrow since c++11
+            bool empty() const nothrow;
+
+            size_type size() const nothrow;
+
+            void clear() nothrow;
+
+            void push_back(ref const Type val);
+
+            void pop_back();
+
+            void push_front(ref const value_type val);
+
+            void pop_front();
+
+            void resize(size_type count);
+
+            void resize(size_type count, ref const value_type val);
+
+            void swap(ref const list!Type other) nothrow;
+
+            void merge( ref const list!Type other);
+
+            void merge(U)(ref const list!Type other, U comp);
+
+            void remove(const ref value_type val);
+
+            void reverse() nothrow;
+
+            void sort();
+
+            void sort(U)(U comp);
+
+            void unique();
+
+            void unique(U)(U p);
+
+            size_type unique();
+
+            size_type unique(U)(U p);
+
+            private struct node
+            {
+                node* prev;
+                node* next;
+            }
+            private node A;
+            private size_type _M_size; //new list keeps track of it's size
+        }
+    }
+    else version (CppRuntime_Microsft)
+    {
+        static assert(0, "Not yet supported!");
+    }
+}

--- a/source/stdcpp/string.d
+++ b/source/stdcpp/string.d
@@ -108,10 +108,22 @@ extern(C++, (StdNamespace)) struct char_traits(CharT)
     }
 }
 
-// I don't think we can have these here, otherwise symbols are emit to druntime, and we don't want that...
-//alias std_string = basic_string!char;
+/**
+ * An alias for `std::string`
+ *
+ * See_Also: https://cplusplus.com/reference/string/string/
+ */
+alias std_string = basic_string!char;
+
 //alias std_u16string = basic_string!wchar; // TODO: can't mangle these yet either...
-//alias std_u32string = basic_string!dchar;
+
+/**
+ * An alias for `std::u32string`
+ *
+ * See_Also: https://cplusplus.com/reference/string/u32string/
+ */
+alias std_u32string = basic_string!dchar;
+
 //alias std_wstring = basic_string!wchar_t; // TODO: we can't mangle wchar_t properly (yet?)
 
 /**
@@ -1406,8 +1418,6 @@ extern(D):
         }
         else
         {
-            pragma(msg, "libstdc++ std::__cxx11::basic_string is not yet supported; the struct contains an interior pointer which breaks D move semantics!");
-
             //----------------------------------------------------------------------------------
             // GCC/libstdc++ modern implementation
             //----------------------------------------------------------------------------------

--- a/source/stdcpp/test/list.d
+++ b/source/stdcpp/test/list.d
@@ -1,0 +1,37 @@
+/*******************************************************************************
+
+    Tests for std::list
+
+*******************************************************************************/
+
+module stdcpp.test.list;
+
+import stdcpp.list;
+
+unittest
+{
+    auto p = list!int(5);
+    p.push_back(5);
+    assert(p.sizeof == 24);
+    assert(p.size() == 6);
+    assert(p.front() == 0);
+    assert(p.back() == 5);
+    p.push_front(7);
+    assert(p.front() == 7);
+    p.clear();
+    assert(p.size() == 0);
+    p.assign(5,5);
+    assert(p.size == 5);
+    p.pop_front();
+    assert(p.size == 4);
+    p.resize(3);
+    assert(p.size == 3);
+
+    list!int cp_obj = p; //opAssign
+    assert(cp_obj.size == 3);
+    cp_obj.clear();
+    cp_obj.push_back(45);
+    cp_obj.push_back(56);
+    assert(cp_obj.front == 45);
+    assert(cp_obj.back == 56);
+}

--- a/source/stdcpp/test/string.d
+++ b/source/stdcpp/test/string.d
@@ -1,0 +1,18 @@
+/*******************************************************************************
+
+    Tests for `std::string`
+
+*******************************************************************************/
+
+module stdcpp.test.string;
+import stdcpp.string;
+
+unittest
+{
+    auto a = std_string("hello");
+    a.push_back('a');
+    assert(a.size() == 6);
+    assert(std_string.sizeof == 32);
+    // verifying small string optimization
+    assert(a.capacity == 15);
+}

--- a/source/stdcpp/test/vector.d
+++ b/source/stdcpp/test/vector.d
@@ -10,8 +10,63 @@ import stdcpp.vector;
 
 unittest
 {
-    vector!int vec;
+    auto vec = vector!int(4);
     vec.push_back(42);
-    assert(vec.length == 1);
-    assert(vec[0] == 42);
+    assert(vec.length == 5);
+    assert(vec[4] == 42);
+    assert(vec.at(3) == 0);
+    vec.pop_back();
+    assert(vec.length == 4);
+    vec.clear();
+    assert(vec.empty == 1);
+    vec.push_back(7);
+    vector!int new_vec = vec; //opAssign test
+    auto it = new_vec.begin();
+    assert(*(it) == 7);
+}
+
+unittest
+{
+    auto p = vector!int(4,9);
+    assert(p.capacity() == 4);
+    p.reserve(6);
+    assert(p.capacity() == 6);
+    //3 push backs to reallocate memory by 2 after initially capacity fills up
+    p.push_back(9);
+    p.push_back(9);//capacity is 6 now
+    p.push_back(9);
+    assert(p.capacity() == 12);
+    p.resize(5);
+    assert(p.length == 5);
+    assert(p.sizeof == 24);//verifying three pointers
+    p.assign(3,8);
+    assert(p.length == 3);
+    p.push_back(4);
+    p.push_back(9);
+    auto iter = p.begin();
+    //single iteration movements
+    assert(*(iter) == 8);
+    iter++;
+    assert(*(iter) == 8);
+    iter++;
+    assert(*(iter) == 8);
+    iter++;
+    assert(*(iter) == 4);
+    iter++;
+    assert(*(iter) == 9); // 8,8,8,4,9 in that order
+}
+
+unittest
+{
+    import stdcpp.allocator;
+    allocator!int alloc_instance = allocator!(int).init;
+    auto q = vector!int(alloc_instance);
+    q.push_back(4);
+    assert(q[0] == 4);
+    assert(q.length == 1);
+    auto cp_ctor = vector!int(q); // copy constructor
+    assert(cp_ctor[0] == 4);
+    assert(cp_ctor.length == 1);
+    auto iter = cp_ctor.begin();
+    assert(*(iter) == 4); // first element in vector
 }


### PR DESCRIPTION
This adds support and test for C++'s `<vector>` and `<list>` headers on POSIX (Linux / Mac OS) platforms.

This is just doing minor changes to the work made by @Emmankoko . All credit should go to him. See #3 .