### PR TITLE
Fix macOS build issue for vector and list

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,13 +34,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - { name: ubuntu-20.04, arch: x86_64-linux-gnu-ubuntu-20.04 }
-        dc:
-          - ldc-latest
-        target:
-          - { name: g++-9, compiler: g++, cxx-version: 9.4.0 }
-          - { name: clang-13, compiler: clang, cxx-version: 13.0.0 }
+        include:
+          - os: { name: ubuntu-20.04, arch: x86_64-linux-gnu-ubuntu-20.04 }
+            target: { name: g++-9, compiler: g++, cxx-version: 9.4.0 }
+            dc: ldc-latest
+          - os: { name: ubuntu-20.04, arch: x86_64-linux-gnu-ubuntu-20.04 }
+            target: { name: clang-13, compiler: clang, cxx-version: 13.0.0 }
+            dc: ldc-latest
+          - os: { name: macOS-12, arch: x86_64-apple-darwin }
+            target: { name: clang-15, compiler: clang, cxx-version: 13.0.0 }
+            dc: ldc-latest
+#          - os: { name: macOS-13-xlarge, arch: arm64-apple-darwin }
+#            target: { name: clang-15, compiler: clang, cxx-version: 15.0.1 }
+#            dc: ldc-latest
 
     # Using a specific version for reproductibility.
     # Feel free to update when a new release has matured.

--- a/dub.json
+++ b/dub.json
@@ -13,7 +13,9 @@
         },
         {
             "name": "unittest",
-            "lflags": [ "-lstdc++" ],
+            "lflags-posix": [ "-lstdc++" ],
+            "lflags-linux": [ "--export-dynamic" ],
+            "lflags-osx": [ "-export_dynamic" ],
             "preGenerateCommands": [
                 "$PACKAGE_DIR/extras/cxx-wrapper.sh vector",
                 "$PACKAGE_DIR/extras/cxx-wrapper.sh list"

--- a/source/stdcpp/list.d
+++ b/source/stdcpp/list.d
@@ -286,7 +286,7 @@ extern(C++, class) struct list(Type, Allocator)
             private size_type _M_size; //new list keeps track of it's size
         }
     }
-    else version (CppRuntime_Microsft)
+    else version (CppRuntime_Clang)
     {
         this(def)
         {
@@ -410,6 +410,10 @@ extern(C++, class) struct list(Type, Allocator)
         void unique(U)(U p);
 
         private __list_imp!(value_type, allocator!Type) base;
+    }
+    else
+    {
+        static assert(0, "CppRuntime not yet supported");
     }
 }
 

--- a/source/stdcpp/list.d
+++ b/source/stdcpp/list.d
@@ -288,103 +288,95 @@ extern(C++, class) struct list(Type, Allocator)
     }
     else version (CppRuntime_Clang)
     {
-        this(def)
-        {
-            allocator!Type alloc_instance = allocator!(Type).init;
-            this(alloc_instance);
-        }
-
         ///
         this(ref const allocator!Type);
 
         /// Copy constructor
         this(ref const list!Type __x);
 
+        this(size_type __n, ref const value_type value);
         ///
-        this(size_type __n, ref const value_type value, ref const allocator!Type);
-
         extern(D) this(size_type n, const value_type element)
         {
-            allocator!Type alloc_instance = allocator!(Type).init;
-            this(n, element, alloc_instance);
+            this(n, element);
         }
 
         this(ref const list!Type other, ref const allocator!Type);
 
         this(size_type __n, ref const allocator!Type);
-
+        ///
         this(size_type n);
-
+        ///
         ~this();
-
+        ///
         extern(D) void assign(size_type n, const value_type item)
         {
             this.assign(n, item);
         }
-
+        ///
         extern(D) void push_back(const Type item)
         {
             this.push_back(item);
         }
-
+        ///
         extern(D) void push_front(const Type item)
         {
             this.push_front(item);
         }
-
+        ///
         extern(D) void resize(size_type n, const value_type item)
         {
             this.resize(n, item);
         }
-
+        ///
         extern(D) void remove(const value_type item)
         {
             this.remove(item);
         }
-
+        ///
         ref list opAssign(ref const list!Type other);
-
+        ///
         void assign(size_type count, ref const value_type value);
-
+        ///
         allocator_type get_allocator() const nothrow;
-
+        ///
         ref value_type front()
         {
             assert(!empty, "list.front called on empty list");
             return base.__end_.next.__as_node.__get_value;
         }
-
+        ///
         ref value_type back()
         {
             assert(!empty, "list.back called on empty list");
             return base.__end_.prev.__as_node.__get_value;
         }
-
+        ///
         pointer begin() nothrow;
-
+        ///
         pointer end() nothrow;
-
+        ///
         bool empty() const nothrow
         {
             return base.empty();
         }
-
+        ////
         size_type size() const nothrow
         {
             return base.__sz();
         }
-
+        ///
         void clear() nothrow
         {
             base.clear();
         }
 
         void push_back(ref const Type val);
-
+        ///
         void pop_back();
 
         void push_front(ref const value_type val);
-
+        ///
         void pop_front();
 
         void resize(size_type count);
@@ -482,12 +474,6 @@ version (CppRuntime_Clang)
         }
 
         bool empty() const nothrow  {return __sz() == 0; }
-
-        void __unlink_nodes(__list_node_base!(value_tp,void_pointer)* __f, __list_node_base!(value_tp, void_pointer)* __l) nothrow
-        {
-            __f.prev.next = __l.next;
-            __l.next.prev = __f.prev;
-        }
 
         void clear() nothrow;
     }

--- a/source/stdcpp/test/string.d
+++ b/source/stdcpp/test/string.d
@@ -6,13 +6,15 @@
 
 module stdcpp.test.string;
 import stdcpp.string;
-
-unittest
+version (CppRuntime_Gcc)
 {
-    auto a = std_string("hello");
-    a.push_back('a');
-    assert(a.size() == 6);
-    assert(std_string.sizeof == 32);
-    // verifying small string optimization
-    assert(a.capacity == 15);
+    unittest
+    {
+        auto a = std_string("hello");
+        a.push_back('a');
+        assert(a.size() == 6);
+        assert(std_string.sizeof == 32);
+        // verifying small string optimization
+        assert(a.capacity == 15);
+    }
 }

--- a/source/stdcpp/test/vector.d
+++ b/source/stdcpp/test/vector.d
@@ -7,66 +7,99 @@
 module stdcpp.test.vector;
 
 import stdcpp.vector;
-
-unittest
+version (CppRuntime_Gcc)
 {
-    auto vec = vector!int(4);
-    vec.push_back(42);
-    assert(vec.length == 5);
-    assert(vec[4] == 42);
-    assert(vec.at(3) == 0);
-    vec.pop_back();
-    assert(vec.length == 4);
-    vec.clear();
-    assert(vec.empty == 1);
-    vec.push_back(7);
-    vector!int new_vec = vec; //opAssign test
-    auto it = new_vec.begin();
-    assert(*(it) == 7);
+    unittest
+    {
+        auto vec = vector!int(4);
+        vec.push_back(42);
+        assert(vec.length == 5);
+        assert(vec[4] == 42);
+        assert(vec.at(3) == 0);
+        vec.pop_back();
+        assert(vec.length == 4);
+        vec.clear();
+        assert(vec.empty == 1);
+        vec.push_back(7);
+        vector!int new_vec = vec; //opAssign test
+        auto it = new_vec.begin();
+        assert(*(it) == 7);
+    }
+
+    unittest
+    {
+        auto p = vector!int(4,9);
+        assert(p.capacity() == 4);
+        p.reserve(6);
+        assert(p.capacity() == 6);
+        //3 push backs to reallocate memory by 2 after initially capacity fills up
+        p.push_back(9);
+        p.push_back(9);//capacity is 6 now
+        p.push_back(9);
+        assert(p.capacity() == 12);
+        p.resize(5);
+        assert(p.length == 5);
+        assert(p.sizeof == 24);//verifying three pointers
+        p.assign(3,8);
+        assert(p.length == 3);
+        p.push_back(4);
+        p.push_back(9);
+        auto iter = p.begin();
+        //single iteration movements
+        assert(*(iter) == 8);
+        iter++;
+        assert(*(iter) == 8);
+        iter++;
+        assert(*(iter) == 8);
+        iter++;
+        assert(*(iter) == 4);
+        iter++;
+        assert(*(iter) == 9); // 8,8,8,4,9 in that order
+    }
+
+    unittest
+    {
+        import stdcpp.allocator;
+        allocator!int alloc_instance = allocator!(int).init;
+        auto q = vector!int(alloc_instance);
+        q.push_back(4);
+        assert(q[0] == 4);
+        assert(q.length == 1);
+        auto cp_ctor = vector!int(q); // copy constructor
+        assert(cp_ctor[0] == 4);
+        assert(cp_ctor.length == 1);
+        auto iter = cp_ctor.begin();
+        assert(*(iter) == 4); // first element in vector
+    }
 }
-
-unittest
+else version (CppRuntime_Clang)
 {
-    auto p = vector!int(4,9);
-    assert(p.capacity() == 4);
-    p.reserve(6);
-    assert(p.capacity() == 6);
-    //3 push backs to reallocate memory by 2 after initially capacity fills up
-    p.push_back(9);
-    p.push_back(9);//capacity is 6 now
-    p.push_back(9);
-    assert(p.capacity() == 12);
-    p.resize(5);
-    assert(p.length == 5);
-    assert(p.sizeof == 24);//verifying three pointers
-    p.assign(3,8);
-    assert(p.length == 3);
-    p.push_back(4);
-    p.push_back(9);
-    auto iter = p.begin();
-    //single iteration movements
-    assert(*(iter) == 8);
-    iter++;
-    assert(*(iter) == 8);
-    iter++;
-    assert(*(iter) == 8);
-    iter++;
-    assert(*(iter) == 4);
-    iter++;
-    assert(*(iter) == 9); // 8,8,8,4,9 in that order
-}
+    unittest
+    {
+        auto vec = vector!int(5);
+        assert(vec.length == 5);
+        assert(vec[3] == 0);
+        assert(vec.empty == 0);
+        vec.reserve(6);
+        assert(vec.capacity == 6);
+        assert(vec.sizeof == 24);
+        vec.assign(3,8);
+        assert(vec.length == 3);
+        assert(vec[0] == 8);
+        assert(vec[1] == 8);
+        assert(vec[2] == 8);
+        vec.resize(9);
+        assert(vec.size == 9);
 
-unittest
-{
-    import stdcpp.allocator;
-    allocator!int alloc_instance = allocator!(int).init;
-    auto q = vector!int(alloc_instance);
-    q.push_back(4);
-    assert(q[0] == 4);
-    assert(q.length == 1);
-    auto cp_ctor = vector!int(q); // copy constructor
-    assert(cp_ctor[0] == 4);
-    assert(cp_ctor.length == 1);
-    auto iter = cp_ctor.begin();
-    assert(*(iter) == 4); // first element in vector
+        auto vec2 = vector!int(7,4);
+        assert(vec2.size == 7);
+        auto vec3 = vector!int(vec2); // copy ctor
+        assert(vec3.size == 7);
+        vec3.swap(vec);
+        assert(vec3.size == 9); // after swap
+        assert(vec.size == 7);
+
+
+
+    }
 }

--- a/source/stdcpp/vector.d
+++ b/source/stdcpp/vector.d
@@ -23,17 +23,14 @@ module stdcpp.vector;
 
 import stdcpp.allocator;
 
-version(CppRuntime_Gcc)
-    version = Non_microsoft;
-else version(CppRuntime_Clang)
-    version = Non_microsoft;
+import stdcpp.xutility : StdNamespace;
 
 enum DefaultConstruct { value }
 
 /// Constructor argument for default construction
 enum Default = DefaultConstruct();
 
-extern(C++, "std"):
+extern(C++, (StdNamespace)):
 
 alias vector(T) = vector!(T, allocator!T);
 extern(C++, class) struct vector(T, Alloc)
@@ -166,7 +163,24 @@ extern(D):
 
         ///
         ~this()		                                                             { _Tidy(); }
+        ~this()		                                                             { _Tidy(); }
 
+        ///
+        ref vector opAssign(T[] array)
+        {
+            clear();
+            reserve(array.length);
+            insert(0, array);
+            return this;
+        }
+
+        ///
+        ref vector opOpAssign(string op : "~")(auto ref T item)                 { push_back(forward!item); return this; }
+        ///
+        ref vector opOpAssign(string op : "~")(T[] array)                       { insert(length, array); return this; }
+
+        ///
+        void append(T[] array)                                                  { insert(length, array);}
         ///
         ref vector opAssign(T[] array)
         {
@@ -201,6 +215,12 @@ extern(D):
         inout(T)[] as_array() inout pure nothrow @trusted @nogc             { return _Get_data()._Myfirst[0 .. size()]; }
         ///
         ref inout(T) at(size_type i) inout pure nothrow @trusted @nogc      { return _Get_data()._Myfirst[0 .. size()][i]; }
+
+        ///
+        void push_back(U)(auto ref U element)
+        {
+            emplace_back(forward!element);
+        }
 
         ///
         void push_back(U)(auto ref U element)
@@ -758,7 +778,7 @@ extern(D):
         inout(T)[] as_array() inout pure nothrow @trusted @nogc             { return null; }
         ref inout(T) at(size_type i) inout pure nothrow @trusted @nogc      { data()[0]; }
     }
-    else version (Non_microsoft)
+    else version (CppRuntime_Gcc)
     {
         pointer _M_start;
         pointer _M_finish;
@@ -837,6 +857,74 @@ extern(D):
         extern(C++) pointer begin() nothrow;
 
         extern(C++) pointer end() nothrow;
+    }
+    else version (CppRuntime_Clang)
+    {
+        pointer __begin_ =  null;
+        pointer __end_ = null;
+        auto __end_cap_ = __compressed_pair!(pointer, allocator_type)(null, __default_init_tag());
+
+        inout(T)[] as_array() inout pure nothrow @trusted @nogc         {return this.__begin_[0 .. size()];}
+
+        inout(value_type)* data() inout nothrow
+        {
+            return this.__begin_;
+        }
+
+        ref inout(pointer) __end_cap() inout nothrow
+        {
+            return this.__end_cap_.first();
+        }
+
+        ///vector(n) constructor
+        extern(C++) this(size_t __n);
+
+        ///copy constructor
+        extern(C++) this(ref const vector vec);
+
+        ///vector(n, value) constructor
+        extern(C++) this(size_t __n, const ref T value);
+
+        extern(D) this(size_t n, const T item)
+        {
+            this(n, item);
+        }
+
+        ///
+        extern(C++) size_type max_size() const nothrow;
+        ///
+        extern(C++) size_t capacity() const @safe nothrow pure @nogc
+        {
+            return cast(size_type)(__end_cap() - this.__begin_);
+        }
+        ///
+        ref inout(T) at(size_t __n) inout pure nothrow @nogc            {return this.__begin_[0 .. size()][__n];}
+
+        ///
+        size_t size() const pure nothrow @safe @nogc
+        {
+            return size_type(this.__end_ - this.__begin_);
+        }
+
+        ///
+        bool empty() const nothrow
+        {
+            return this.__begin_ == this.__end_;
+        }
+
+        ///
+        extern(C++) void reserve(size_t __n);
+        ///
+        extern(C++) void resize(size_t __n);
+
+        extern(C++) void assign(size_t __n, ref const T __x);
+        ///
+        extern(D) void assign(size_t n, const T x)
+        {
+            return this.assign(n,x);
+        }
+        ///
+        extern(C++) void swap(ref vector x);
     }
 }
 
@@ -931,4 +1019,10 @@ version (CppRuntime_Microsoft)
             _Myvec.pointer _Ptr;
         }
     }
+}
+else version (CppRuntime_Clang)
+{
+    import stdcpp.xutility : __compressed_pair;
+    // an auxiliary struct for inittialization of compressed_pair
+    extern (C++) struct __default_init_tag{}
 }

--- a/source/stdcpp/xutility.d
+++ b/source/stdcpp/xutility.d
@@ -352,11 +352,17 @@ package:
 else version (CppRuntime_Clang)
 {
     import stdcpp.type_traits : is_empty;
+    import core.lifetime : forward;
 
 extern(C++, "std"):
 
     extern (C++, class) struct __compressed_pair(_T1, _T2)
     {
+        this(_U1, _U2)(auto ref _U1 __t1, auto ref _U2 __t2)
+        {
+            __value1_ = forward!(__t1);
+        }
+
     pragma (inline, true):
     extern(D):
         enum Ty1Empty = is_empty!_T1.value;


### PR DESCRIPTION
vector is not the only container that is disturbed, list is disturbed as well. stdcpp.test.string also disturbes the build. these contains tests for only available functions in the compilation block for macOS and a few improvements on list as well