### PR TITLE
Make sizeof test to runtime, query the C++ compiler

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -17,15 +17,13 @@
             "lflags-linux": [ "--export-dynamic" ],
             "lflags-osx": [ "-export_dynamic" ],
             "preGenerateCommands-posix": [
-                "$PACKAGE_DIR/extras/cxx-wrapper.sh vector",
-                "$PACKAGE_DIR/extras/cxx-wrapper.sh list"
+                "$PACKAGE_DIR/extras/cxx-wrapper.sh test",
             ],
             "preGenerateCommands-windows": [
-                "cl /c /Fo: $PACKAGE_DIR/extras/ $PACKAGE_DIR/extras/vector.cpp",
-                "cl /c /Fo: $PACKAGE_DIR/extras/ $PACKAGE_DIR/extras/list.cpp",
+                "cl /c /Fo: $PACKAGE_DIR/extras/ $PACKAGE_DIR/extras/test.cpp",
             ],
-            "sourceFiles-posix": [ "extras/*.o" ],
-            "sourceFiles-windows": [ "extras/*.obj" ]
+            "sourceFiles-posix": [ "extras/test.o" ],
+            "sourceFiles-windows": [ "extras/test.obj" ]
         }
     ]
 }

--- a/extras/list.cpp
+++ b/extras/list.cpp
@@ -1,3 +1,0 @@
-#include <list>
-
-template class std::list<int>;

--- a/extras/test.cpp
+++ b/extras/test.cpp
@@ -1,0 +1,14 @@
+/*******************************************************************************
+
+    C++ source code to support stdcpp unittests
+
+    In order to ensure compatibility with C++, we instantiate those
+    C++ templates (with gcc, clang, or cl) and use them from the D code.
+
+*******************************************************************************/
+
+#include <list>
+#include <vector>
+
+template class std::list<int>;
+template class std::vector<int>;

--- a/extras/test.cpp
+++ b/extras/test.cpp
@@ -10,5 +10,17 @@
 #include <list>
 #include <vector>
 
+namespace stdcpp {
+    namespace test {
+        template<typename T>
+        std::size_t cppSizeOf() {
+            return sizeof(T);
+        }
+    };
+};
+
 template class std::list<int>;
+template std::size_t stdcpp::test::cppSizeOf<std::list<int> >();
+
 template class std::vector<int>;
+template std::size_t stdcpp::test::cppSizeOf<std::vector<int> >();

--- a/extras/vector.cpp
+++ b/extras/vector.cpp
@@ -1,3 +1,0 @@
-#include <vector>
-
-template class std::vector<int>;

--- a/source/stdcpp/test/base.d
+++ b/source/stdcpp/test/base.d
@@ -1,0 +1,12 @@
+/*******************************************************************************
+
+    Utilities to be used in tests
+
+*******************************************************************************/
+
+module stdcpp.test.base;
+
+version (unittest):
+
+/// Returns: the `sizeof` of `T` as seen by the C++ compiler
+extern(C++, "stdcpp", "test") size_t cppSizeOf (T) ();

--- a/source/stdcpp/test/list.d
+++ b/source/stdcpp/test/list.d
@@ -6,15 +6,17 @@
 
 module stdcpp.test.list;
 
+import stdcpp.test.base;
 import stdcpp.list;
+
+/// Test that the sizes matches
+unittest
+{
+    assert(cppSizeOf!(list!int) == list!int.sizeof);
+}
 
 unittest
 {
-    version (CppRuntime_Microsoft)
-        static assert(list!int.sizeof == 16);
-    else
-        static assert(list!int.sizeof == 24);
-
     auto p = list!int(5);
     p.push_back(5);
     assert(p.size() == 6);

--- a/source/stdcpp/test/vector.d
+++ b/source/stdcpp/test/vector.d
@@ -6,7 +6,15 @@
 
 module stdcpp.test.vector;
 
+import stdcpp.test.base;
 import stdcpp.vector;
+
+/// Test that the sizes matches
+unittest
+{
+    assert(cppSizeOf!(vector!int) == vector!int.sizeof);
+}
+
 version (CppRuntime_Gcc)
 {
     unittest
@@ -39,7 +47,6 @@ version (CppRuntime_Gcc)
         assert(p.capacity() == 12);
         p.resize(5);
         assert(p.length == 5);
-        assert(p.sizeof == 24);//verifying three pointers
         p.assign(3,8);
         assert(p.length == 3);
         p.push_back(4);
@@ -82,7 +89,6 @@ else version (CppRuntime_Clang)
         assert(vec.empty == 0);
         vec.reserve(6);
         assert(vec.capacity == 6);
-        assert(vec.sizeof == 24);
         vec.assign(3,8);
         assert(vec.length == 3);
         assert(vec[0] == 8);
@@ -98,8 +104,5 @@ else version (CppRuntime_Clang)
         vec3.swap(vec);
         assert(vec3.size == 9); // after swap
         assert(vec.size == 7);
-
-
-
     }
 }

--- a/source/stdcpp/vector.d
+++ b/source/stdcpp/vector.d
@@ -163,24 +163,7 @@ extern(D):
 
         ///
         ~this()		                                                             { _Tidy(); }
-        ~this()		                                                             { _Tidy(); }
 
-        ///
-        ref vector opAssign(T[] array)
-        {
-            clear();
-            reserve(array.length);
-            insert(0, array);
-            return this;
-        }
-
-        ///
-        ref vector opOpAssign(string op : "~")(auto ref T item)                 { push_back(forward!item); return this; }
-        ///
-        ref vector opOpAssign(string op : "~")(T[] array)                       { insert(length, array); return this; }
-
-        ///
-        void append(T[] array)                                                  { insert(length, array);}
         ///
         ref vector opAssign(T[] array)
         {


### PR DESCRIPTION
```
We should strive to query the C++ compiler as much as possible
instead of relying on hardcoded values, as it ensures that
any change (new standard, new compiler, new platform) will
catch the bug, which relying on hardcoded value will not.
```