### PR TITLE
pop_back function for vector on CppRuntime_Clang

### DIFF
--- a/source/stdcpp/allocator.d
+++ b/source/stdcpp/allocator.d
@@ -205,6 +205,11 @@ extern(D):
 
         ///
         enum size_t max_size = size_t.max / T.sizeof;
+
+        void __destroy(pointer __p)
+        {
+            destroy!false(__p);
+        }
     }
     else
     {
@@ -265,6 +270,14 @@ struct allocator_traits(Alloc)
             return a.select_on_container_copy_construction();
         else
             return a;
+    }
+
+    version (CppRuntime_Clang)
+    {
+        static void Destroy(ref Alloc alloc, pointer __p)
+        {
+            alloc.__destroy(__p);
+        }
     }
 }
 

--- a/source/stdcpp/test/vector.d
+++ b/source/stdcpp/test/vector.d
@@ -104,5 +104,11 @@ else version (CppRuntime_Clang)
         vec3.swap(vec);
         assert(vec3.size == 9); // after swap
         assert(vec.size == 7);
+        vec.pop_back();
+        assert(vec.size == 6);
+        vec.pop_back();
+        assert(vec.size == 5);
+        vec.pop_back();
+        assert(vec.size == 4);
     }
 }


### PR DESCRIPTION
With functions like pop_back and push_back, there have been recent ASAN(address sanitization) annotations that have been added to check for some memory poisoning with the unsafe usage of unused capacity since reallocations can produce larger capacity than the number of elements in the container so there will be few unused memory that will not be safe to use. I looked through it, and It is whole poisoning runtime library not part of the STL. 

I think now that we have pop_back working, there's a Todo comment left in pop_back function which I think will be good for us to integrate that as a future work.

can check it out here:
[PATCH](https://gcc.gnu.org/pipermail/libstdc++/2017-July/046127.html)
[Library](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/asan/asan_poisoning.cpp#L407)
