### PR TITLE
Adding opAssign tests for all three runtimes

### DIFF
--- a/source/stdcpp/list.d
+++ b/source/stdcpp/list.d
@@ -57,9 +57,6 @@ extern(C++, class) struct list(Type, Allocator)
     alias difference_type = ptrdiff_t;
 
     ///
-    ref list opAssign();
-
-    ///
     @disable this() @safe pure nothrow @nogc scope;
 
     version (CppRuntime_Gcc)
@@ -334,7 +331,14 @@ extern(C++, class) struct list(Type, Allocator)
             this.remove(item);
         }
         ///
-        ref list opAssign(ref const list!Type other);
+        ref list opAssign(ref const list other)
+        {
+            import core.lifetime : emplace;
+
+            destroy!false(this);
+            emplace!(list)(&this, other);
+            return this;
+        }
         ///
         void assign(size_type count, ref const value_type value);
         ///
@@ -574,5 +578,12 @@ version (CppRuntime_Clang)
         bool empty() const nothrow  {return __sz() == 0; }
 
         void clear() nothrow;
+
+        void __copy_assign_alloc(const ref __list_imp __c)
+        {
+            if (__node_alloc() != __c.__node_alloc())
+                clear();
+            __node_alloc() = __c.__node_alloc();
+        }
     }
 }

--- a/source/stdcpp/test/list.d
+++ b/source/stdcpp/test/list.d
@@ -33,11 +33,19 @@ unittest
     p.resize(3);
     assert(p.size == 3);
 
-    list!int cp_obj = p; //opAssign
+    list!int cp_obj = p; // copy ctor
     assert(cp_obj.size == 3);
     cp_obj.clear();
     cp_obj.push_back(45);
     cp_obj.push_back(56);
     assert(cp_obj.front == 45);
     assert(cp_obj.back == 56);
+}
+
+unittest
+{
+    import stdcpp.allocator;
+    allocator!int alloc_instance = allocator!(int).init;
+    auto q = list!int(8, 9);
+    assert(q.get_allocator == alloc_instance);
 }

--- a/source/stdcpp/test/list.d
+++ b/source/stdcpp/test/list.d
@@ -48,4 +48,8 @@ unittest
     allocator!int alloc_instance = allocator!(int).init;
     auto q = list!int(8, 9);
     assert(q.get_allocator == alloc_instance);
+    assert(q.size == 8);
+    auto p = list!int(3);
+    q = p; // opAssign
+    assert(q.size == 3); // after opAssign
 }


### PR DESCRIPTION
opAssign function was not available for linking on macOS. but available for the other runtimes. so the approach here is to destroy the current list object(this), emplace the new object in the current object's(this) address, and return it. 